### PR TITLE
feat(operator): Associate operators with entities in create/edit forms

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -914,6 +914,7 @@
     "radius_endpoint_other": "Radius Endpoints"
   },
   "operator": {
+    "associate_entity": "Associate with Entity",
     "delete_explanation": "Are you sure you want to delete this operator? This operation is not reversible",
     "delete_operator": "Delete Operator",
     "import_location_from_device": "Import from other Device",

--- a/src/components/Modals/Operator/CreateOperatorModal/Form.jsx
+++ b/src/components/Modals/Operator/CreateOperatorModal/Form.jsx
@@ -6,8 +6,10 @@ import { useTranslation } from 'react-i18next';
 import { v4 as uuid } from 'uuid';
 import DeviceRulesField from 'components/CustomFields/DeviceRulesField';
 import IpDetectionModalField from 'components/CustomFields/IpDetectionModalField';
+import SelectWithSearchField from 'components/FormFields/SelectWithSearchField';
 import StringField from 'components/FormFields/StringField';
 import { CreateOperatorSchema } from 'constants/formSchemas';
+import { useGetEntities } from 'hooks/Network/Entity';
 import { useCreateOperator } from 'hooks/Network/Operators';
 import useMutationResult from 'hooks/useMutationResult';
 
@@ -27,13 +29,16 @@ const CreateOperatorForm = ({ isOpen, onClose, refresh, formRef }) => {
     refresh,
     onClose,
   });
+  const { data: entities } = useGetEntities();
   const create = useCreateOperator();
+  const entityOptions = entities?.map((ent) => ({ value: ent.id, label: `${ent.name}${ent.description ? `: ${ent.description}` : ''}` })) ?? [];
 
-  const createParameters = ({ name, description, note, sourceIP, deviceRules, firmwareRCOnly, registrationId }) => ({
+  const createParameters = ({ name, description, note, sourceIP, deviceRules, firmwareRCOnly, registrationId, entityId }) => ({
     name,
     deviceRules,
     sourceIP,
     registrationId,
+    entityId,
     description,
     firmwareRCOnly,
     notes: note.length > 0 ? [{ note }] : undefined,
@@ -56,6 +61,7 @@ const CreateOperatorForm = ({ isOpen, onClose, refresh, formRef }) => {
           firmwareUpgrade: 'inherit',
         },
         registrationId: '',
+        entityId: '',
         firmwareRCOnly: false,
         sourceIP: [],
         note: '',
@@ -77,6 +83,7 @@ const CreateOperatorForm = ({ isOpen, onClose, refresh, formRef }) => {
           <StringField name="name" label={t('common.name')} isRequired />
           <StringField name="description" label={t('common.description')} />
           <StringField name="registrationId" label={t('operator.registration_id')} isRequired />
+          <SelectWithSearchField name="entityId" label={t('operator.associate_entity')} options={entityOptions} isRequired isPortal />
           <DeviceRulesField />
           <IpDetectionModalField name="sourceIP" />
           <StringField name="note" label={t('common.note')} />

--- a/src/constants/formSchemas.ts
+++ b/src/constants/formSchemas.ts
@@ -476,6 +476,7 @@ export const CreateOperatorSchema = (t: (str: string) => string) =>
     description: Yup.string(),
     deviceRules: DeviceRulesSchema(t).required('form.required'),
     registrationId: Yup.string().required(t('form.required')),
+    entityId: Yup.string().required(t('form.required')),
     sourceIP: Yup.array().of(Yup.string()),
   });
 export const EditOperatorSchema = (t: (str: string) => string) =>
@@ -483,5 +484,6 @@ export const EditOperatorSchema = (t: (str: string) => string) =>
     name: Yup.string().required(t('form.required')).test('name_test', t('common.name_error'), testObjectName),
     description: Yup.string(),
     deviceRules: DeviceRulesSchema(t).required('form.required'),
+    entityId: Yup.string().required(t('form.required')),
     sourceIP: Yup.array().of(Yup.string()),
   });

--- a/src/hooks/Network/Operators.ts
+++ b/src/hooks/Network/Operators.ts
@@ -10,6 +10,7 @@ import { axiosProv } from 'utils/axiosInstances';
 
 export type CreateOperatorRequest = {
   deviceRules: DeviceRules;
+  entityId: string;
   sourceIp: string;
   registrationId: string;
   description?: string;
@@ -20,6 +21,7 @@ export type CreateOperatorRequest = {
 export type UpdateOperatorRequest = {
   defaultOperator?: boolean;
   devicesRules?: DeviceRules;
+  entityId?: string;
   name?: string;
   notes?: Note[];
   registrationId?: string;
@@ -29,6 +31,7 @@ export type OperatorApiResponse = {
   created: number;
   defaultOperator: boolean;
   devicesRules: DeviceRules;
+  entityId?: string;
   extendedInfo?: Record<string, unknown>;
   id: string;
   modified: number;

--- a/src/pages/OperatorPage/DetailsCard/Form.jsx
+++ b/src/pages/OperatorPage/DetailsCard/Form.jsx
@@ -8,9 +8,11 @@ import DeviceRulesField from 'components/CustomFields/DeviceRulesField';
 import IpDetectionModalField from 'components/CustomFields/IpDetectionModalField';
 import NotesTable from 'components/CustomFields/NotesTable';
 import FormattedDate from 'components/FormattedDate';
+import SelectWithSearchField from 'components/FormFields/SelectWithSearchField';
 import StringField from 'components/FormFields/StringField';
 import { EditOperatorSchema } from 'constants/formSchemas';
 import { EntityShape } from 'constants/propShapes';
+import { useGetEntities } from 'hooks/Network/Entity';
 import { useUpdateOperator } from 'hooks/Network/Operators';
 import useMutationResult from 'hooks/useMutationResult';
 
@@ -24,6 +26,8 @@ const propTypes = {
 const EditOperatorForm = ({ editing, operator, formRef, stopEditing }) => {
   const { t } = useTranslation();
   const [formKey, setFormKey] = useState(uuid());
+  const { data: entities } = useGetEntities();
+  const entityOptions = entities?.map((ent) => ({ value: ent.id, label: `${ent.name}${ent.description ? `: ${ent.description}` : ''}` })) ?? [];
   const updateOperator = useUpdateOperator({ id: operator.id });
   const { onSuccess, onError } = useMutationResult({
     objName: t('operator.one'),
@@ -44,7 +48,7 @@ const EditOperatorForm = ({ editing, operator, formRef, stopEditing }) => {
       initialValues={operator}
       validationSchema={EditOperatorSchema(t)}
       onSubmit={(
-        { name, description, deviceRules, sourceIP, firmwareRCOnly, registrationId, notes },
+        { name, description, deviceRules, sourceIP, firmwareRCOnly, registrationId, notes, entityId },
         { setSubmitting, resetForm },
       ) =>
         updateOperator.mutateAsync(
@@ -55,6 +59,7 @@ const EditOperatorForm = ({ editing, operator, formRef, stopEditing }) => {
             sourceIP,
             firmwareRCOnly,
             registrationId,
+            entityId,
             notes: notes.filter((note) => note.isNew),
           },
           {
@@ -80,6 +85,7 @@ const EditOperatorForm = ({ editing, operator, formRef, stopEditing }) => {
                 <SimpleGrid minChildWidth="300px" spacing="20px">
                   <StringField name="name" label={t('common.name')} isDisabled={!editing} isRequired />
                   <StringField name="description" label={t('common.description')} isDisabled={!editing} />
+                  <SelectWithSearchField name="entityId" label={t('operator.associate_entity')} options={entityOptions} isDisabled={!editing} isRequired isPortal />
                   <DeviceRulesField isDisabled={!editing} />
                   <IpDetectionModalField name="sourceIP" setFieldValue={setFieldValue} isDisabled={!editing} />
                   <StringField


### PR DESCRIPTION
## What
Require operators to be associated with an entity in create/edit flows.

## Changes
- Add entity selector to operator create/edit forms
- Require `entityId` in validation
- Send `entityId` in create/update payloads
- Add label for the entity association field

## Testing
- Create operator with entity
- Edit operator and verify entity persists