### PR TITLE
Fix timezone offset handling to align with device POSIX rules

### DIFF
--- a/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/ap/sections/UnitSection/Unit.jsx
+++ b/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/ap/sections/UnitSection/Unit.jsx
@@ -57,40 +57,40 @@ const Unit = ({ editing }) => {
               options={[
                 { value: '', label: t('common.none') },
                 {
-                  value: 'UTC-11:00',
+                  value: 'UTC+11:00',
                   label: 'Midway Islands Time (UTC-11:00)',
                 },
                 {
-                  value: 'UTC-10:00',
+                  value: 'UTC+10:00',
                   label: 'Hawaii Standard Time (UTC-10:00)',
                 },
                 {
-                  value: 'UTC-8:00',
+                  value: 'UTC+8:00',
                   label: 'Pacific Standard Time (UTC-8:00)',
                 },
                 {
-                  value: 'UTC-7:00',
+                  value: 'UTC+7:00',
                   label: 'Mountain Standard Time (UTC-7:00)',
                 },
                 {
-                  value: 'UTC-6:00',
+                  value: 'UTC+6:00',
                   label: 'Central Standard Time (UTC-6:00)',
                 },
                 {
-                  value: 'UTC-5:00',
+                  value: 'UTC+5:00',
                   label: 'Eastern Standard Time (UTC-5:00)',
                 },
                 {
-                  value: 'UTC-4:00',
+                  value: 'UTC+4:00',
                   label: 'Puerto Rico and US Virgin Islands Time (UTC-4:00)',
                 },
                 {
-                  value: 'UTC-3:30',
+                  value: 'UTC+3:30',
                   label: 'Canada Newfoundland Time (UTC-3:30)',
                 },
-                { value: 'UTC-3:00', label: 'Brazil Eastern Time (UTC-3:00)' },
+                { value: 'UTC+3:00', label: 'Brazil Eastern Time (UTC-3:00)' },
                 {
-                  value: 'UTC-1:00',
+                  value: 'UTC+1:00',
                   label: 'Central African Time (UTC-1:00)',
                 },
                 {
@@ -98,52 +98,52 @@ const Unit = ({ editing }) => {
                   label: 'Universal Coordinated Time (UTC)',
                 },
                 {
-                  value: 'UTC+1:00',
+                  value: 'UTC-1:00',
                   label: 'European Central Time (UTC+1:00)',
                 },
                 {
-                  value: 'UTC+2:00',
+                  value: 'UTC-2:00',
                   label: 'Eastern European Time (UTC+2:00)',
                 },
                 {
-                  value: 'UTC+2:00',
+                  value: 'UTC-2:00',
                   label: '(Arabic) Egypt Standard Time (UTC+2:00)',
                 },
                 {
-                  value: 'UTC+3:00',
+                  value: 'UTC-3:00',
                   label: 'Eastern African Time (UTC+3:00)',
                 },
-                { value: 'UTC+3:30', label: 'Middle East Time (UTC+3:30)' },
-                { value: 'UTC+4:00', label: 'Near East Time (UTC+4:00)' },
+                { value: 'UTC-3:30', label: 'Middle East Time (UTC+3:30)' },
+                { value: 'UTC-4:00', label: 'Near East Time (UTC+4:00)' },
                 {
-                  value: 'UTC+5:00',
+                  value: 'UTC-5:00',
                   label: 'Pakistan Lahore Time (UTC+5:00)',
                 },
-                { value: 'UTC+5:30', label: 'India Standard Time (UTC+5:30)' },
+                { value: 'UTC-5:30', label: 'India Standard Time (UTC+5:30)' },
                 {
-                  value: 'UTC+6:00',
+                  value: 'UTC-6:00',
                   label: 'Bangladesh Standard Time (UTC+6:00)',
                 },
                 {
-                  value: 'UTC+7:00',
+                  value: 'UTC-7:00',
                   label: 'Vietnam Standard Time (UTC+7:00)',
                 },
-                { value: 'UTC+8:00', label: 'China Taiwan Time (UTC+8:00)' },
-                { value: 'UTC+9:00', label: 'Japan Standard Time (UTC+9:00)' },
+                { value: 'UTC-8:00', label: 'China Taiwan Time (UTC+8:00)' },
+                { value: 'UTC-9:00', label: 'Japan Standard Time (UTC+9:00)' },
                 {
-                  value: 'UTC+9:30',
+                  value: 'UTC-9:30',
                   label: 'Australia Central Time (UTC+9:30)',
                 },
                 {
-                  value: 'UTC+10:00',
+                  value: 'UTC-10:00',
                   label: 'Australia Eastern Time (UTC+10:00)',
                 },
                 {
-                  value: 'UTC+11:00',
+                  value: 'UTC-11:00',
                   label: 'Solomon Standard Time (UTC+11:00)',
                 },
                 {
-                  value: 'UTC+12:00',
+                  value: 'UTC-12:00',
                   label: 'New Zealand Standard Time (UTC+12:00)',
                 },
               ]}

--- a/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/ap/sections/UnitSection/Unit.jsx
+++ b/src/pages/ConfigurationPage/ConfigurationCard/ConfigurationSectionsCard/ap/sections/UnitSection/Unit.jsx
@@ -54,6 +54,10 @@ const Unit = ({ editing }) => {
               definitionKey="unit.timezone"
               emptyIsUndefined
               isDisabled={!editing}
+              // The device expects timezone offsets in POSIX format, where the sign is
+              // inverted compared to standard UTC notation (e.g., UTC+5:30 -> UTC-5:30).
+              // Therefore, these option values are intentionally reversed so the device
+              // applies the correct timezone.
               options={[
                 { value: '', label: t('common.none') },
                 {


### PR DESCRIPTION
Fixes #36

**Summary**
This PR fixes incorrect timezone handling between UI and device by aligning timezone offset values with POSIX format expected by the device.

**Problem**
The UI was sending standard UTC offset values (e.g., UTC+5:30), while the device interprets timezone using POSIX rules where the offset sign is reversed.
Due to this mismatch:
Timezone offsets were applied in the wrong direction
For example, IST (UTC+5:30) resulted in device time being 5:30 behind UTC instead of ahead

**Solutions:**
- Updated timezone value mapping in UI
- Adjusted offset signs before sending configuration to the device
- Ensured compatibility with POSIX timezone interpretation on the device

**Verification (After Fix)**
1. Applying IST (UTC+5:30) from UI
<img width="734" height="260" alt="Screenshot from 2026-04-07 14-01-36" src="https://github.com/user-attachments/assets/163c8816-8835-423f-9e4a-792116c28bad" />

2. Device Time for IST (UTC+5:30) After Fix
- Current UTC time: 10:00:48 UTC
- Device configured timezone: UTC-5:30 (POSIX-adjusted)
- Device reported time: 15:30:50
- The device now correctly shows time 5 hours 30 minutes ahead of UTC
<img width="583" height="188" alt="owpro-ui-after-fix" src="https://github.com/user-attachments/assets/e5e0a2b6-5359-40ef-a1db-54fb07285666" />
